### PR TITLE
Fix naming issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[docker-compose.yml]
+indent_size = 4
+
+[*.{js,vue}]
+indent_size = 4

--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,12 @@
     },
     "autoload": {
         "psr-4": {
-            "StatamicRadPack\\meilisearch\\": "src"
+            "StatamicRadPack\\Meilisearch\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "StatamicRadPack\\meilisearch\\Tests\\": "tests"
+            "StatamicRadPack\\Meilisearch\\Tests\\": "tests"
         }
     },
     "scripts": {
@@ -56,17 +56,14 @@
         }
     },
     "extra": {
-        "statamic": {
-            "name": "meilisearch",
-            "description": "meilisearch search driver for Statamic"
-        },
         "laravel": {
             "providers": [
-                "StatamicRadPack\\meilisearch\\ServiceProvider"
+                "StatamicRadPack\\Meilisearch\\ServiceProvider"
             ]
+        },
+        "statamic": {
+            "name": "Meilisearch",
+            "description": "Meilisearch search driver for Statamic"
         }
-    },
-    "conflict": {
-        "elvenstar/statamic-meilisearch": "*"
     }
 }

--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace StatamicRadPack\meilisearch\meilisearch;
+namespace StatamicRadPack\Meilisearch\Meilisearch;
 
 use Illuminate\Support\Str;
-use meilisearch\Client;
-use meilisearch\Exceptions\ApiException;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
 use Statamic\Contracts\Search\Searchable;
-use Statamic\Entries\Entry;
 use Statamic\Search\Documents;
 use Statamic\Search\Index as BaseIndex;
 

--- a/src/Meilisearch/Query.php
+++ b/src/Meilisearch/Query.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StatamicRadPack\meilisearch\meilisearch;
+namespace StatamicRadPack\Meilisearch\Meilisearch;
 
 use Statamic\Search\QueryBuilder;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace StatamicRadPack\meilisearch;
+namespace StatamicRadPack\Meilisearch;
 
 use Illuminate\Foundation\Application;
-use meilisearch\Client;
+use Meilisearch\Client;
 use Statamic\Facades\Search;
 use Statamic\Providers\AddonServiceProvider;
 
@@ -17,7 +17,7 @@ class ServiceProvider extends AddonServiceProvider
                 'apiKey' => $config['credentials']['secret'],
             ]);
 
-            return $app->makeWith(meilisearch\Index::class, [
+            return $app->makeWith(Meilisearch\Index::class, [
                 'client' => $client,
                 'name' => $name,
                 'config' => $config,


### PR DESCRIPTION
Fix the naming issues in 3.0.0 which were causing the add-on to not install.
