### PR TITLE
Specify a high maxTotalHits and hitsPerPage to avoid pagination issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ You may include different types of settings in each index:
  ],
 ```
 
+### Search Pagination
+
+By default we limit the `maxTotalHits` to 1000000, if you want to modify this or any other pagination settings on the indedx, specify a pagination key:
+
+```php
+// articles
+'articles' => [
+    'driver' => 'meilisearch',
+    'searchables' => ['collection:articles'],
+    'fields' => ['id', 'title', 'url', 'type', 'content', 'locale'],
+    'pagination' => [
+      'maxTotalHits' => 100,
+    ],
+],
+```
+
+
 ### Extending
 
 You can extend the drivers functionality (e.g. in order to customize calls to meilisearch) by creating a class that extends

--- a/src/Mellisearch/Index.php
+++ b/src/Mellisearch/Index.php
@@ -37,7 +37,7 @@ class Index extends BaseIndex
 
     public function delete($document)
     {
-        $this->getIndex()->deleteDocument($this->getSafeDocmentID($document->getSearchReference()));
+        $this->getIndex()->deleteDocument($this->getSafeDocumentID($document->getSearchReference()));
     }
 
     public function exists()
@@ -83,6 +83,7 @@ class Index extends BaseIndex
             }
 
             $this->getIndex()->updateSettings($this->config['settings']);
+            $this->getIndex()->updatePagination($this->config['pagination'] ?? ['maxTotalHits' => 1000000]);
         } catch (ApiException $e) {
             $this->handlemeilisearchException($e, 'createIndex');
         }
@@ -108,10 +109,10 @@ class Index extends BaseIndex
         return $this;
     }
 
-    public function searchUsingApi($query, $filters = [], $options = [])
+    public function searchUsingApi($query, $options = ['hitsPerPage' => 1000000])
     {
         try {
-            $searchResults = $this->getIndex()->search($query, $filters, $options);
+            $searchResults = $this->getIndex()->search($query, $options);
         } catch (\Exception $e) {
             $this->handlemeilisearchException($e, 'searchUsingApi');
         }
@@ -127,7 +128,7 @@ class Index extends BaseIndex
     private function getDefaultFields(Searchable $entry): array
     {
         return [
-            'id' => $this->getSafeDocmentID($entry->getSearchReference()),
+            'id' => $this->getSafeDocumentID($entry->getSearchReference()),
             'reference' => $entry->getSearchReference(),
         ];
     }
@@ -155,7 +156,7 @@ class Index extends BaseIndex
      *
      * @return string
      */
-    private function getSafeDocmentID(string $entryReference)
+    private function getSafeDocumentID(string $entryReference)
     {
         return Str::of($entryReference)
             ->explode('::')


### PR DESCRIPTION
The CP search handles pagination internally so specify a high hitsPerPage and maxTotalHits to allow it to get a full result set then do its own thing from there.

I set these as config variables so a developer can override this if they want.

Closes https://github.com/statamic-rad-pack/meilisearch/issues/16