### PR TITLE
Make use of Meilisearch sorting

### DIFF
--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -116,7 +116,7 @@ class Index extends BaseIndex
             $this->handlemeilisearchException($e, 'searchUsingApi');
         }
 
-        collect($searchResults->getHits())->map(function ($hit) {
+        return collect($searchResults->getHits())->map(function ($hit) {
             $hit['search_score'] = (int) ceil($hit['_rankingScore'] * 1000);
             unset($hit['_rankingScore']);
 

--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Meilisearch\Meilisearch;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Meilisearch\Client;
 use Meilisearch\Exceptions\ApiException;
@@ -108,20 +109,15 @@ class Index extends BaseIndex
         return $this;
     }
 
-    public function searchUsingApi($query, $options = ['hitsPerPage' => 1000000, 'showRankingScore' => true])
+    public function searchUsingApi($query, array $options = ['hitsPerPage' => 1000000, 'showRankingScore' => true]): Collection
     {
         try {
             $searchResults = $this->getIndex()->search($query, $options);
         } catch (\Exception $e) {
-            $this->handlemeilisearchException($e, 'searchUsingApi');
+            $this->handleMeilisearchException($e, 'searchUsingApi');
         }
 
-        return collect($searchResults->getHits())->map(function ($hit) {
-            $hit['search_score'] = (int) ceil($hit['_rankingScore'] * 1000);
-            unset($hit['_rankingScore']);
-
-            return $hit;
-        });
+        return collect($searchResults->getHits());
     }
 
     private function getIndex()
@@ -137,16 +133,18 @@ class Index extends BaseIndex
         ];
     }
 
-    private function handlemeilisearchException($e, $method)
+    /**
+     * Custom error parsing for Meilisearch exceptions.
+     */
+    private function handleMeilisearchException($e, $method)
     {
-        // custom error parsing for meilisearch exceptions
+        // Ignore if already created.
         if ($e->errorCode === 'index_already_exists' && $method === 'createIndex') {
-            // ignore if already created
             return true;
         }
 
+        // Ignore if not found.
         if ($e->errorCode === 'index_not_found' && $method === 'deleteIndex') {
-            // ignore if not found
             return true;
         }
 

--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -108,7 +108,7 @@ class Index extends BaseIndex
         return $this;
     }
 
-    public function searchUsingApi($query, $options = ['hitsPerPage' => 1000000])
+    public function searchUsingApi($query, $options = ['hitsPerPage' => 1000000, 'showRankingScore' => true])
     {
         try {
             $searchResults = $this->getIndex()->search($query, $options);
@@ -116,7 +116,12 @@ class Index extends BaseIndex
             $this->handlemeilisearchException($e, 'searchUsingApi');
         }
 
-        return collect($searchResults->getHits());
+        collect($searchResults->getHits())->map(function ($hit) {
+            $hit['search_score'] = (int) ceil($hit['_rankingScore'] * 1000);
+            unset($hit['_rankingScore']);
+
+            return $hit;
+        });
     }
 
     private function getIndex()

--- a/src/Meilisearch/Query.php
+++ b/src/Meilisearch/Query.php
@@ -8,6 +8,12 @@ class Query extends QueryBuilder
 {
     public function getSearchResults($query)
     {
-        return $this->index->searchUsingApi($query);
+        $results = $this->index->searchUsingApi($query);
+
+        return $results->map(function ($result, $i) {
+            $result['search_score'] = (int) ceil($result['_rankingScore'] * 1000);
+
+            return $result;
+        });
     }
 }


### PR DESCRIPTION
Initial PR: #26

Make use of Statamic score sorting so we can have the results sorted as they appear in Meilisearch and not by UUIID in Statamic.