### PR TITLE
fix insert single document (#32)

### DIFF
--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -28,7 +28,7 @@ class Index extends BaseIndex
 
     public function insert($document)
     {
-        return $this->insertMultiple(collect($document));
+        return $this->insertMultiple(collect([$document]));
     }
 
     public function insertMultiple($documents)


### PR DESCRIPTION
The insert method goes into insertMultiple, but collects on the entry. So the insertMultiple tries to insert all the Entry's properties as documents to the index.

See #32 