### PR TITLE
Allow sorting by using `orderBy`

### DIFF
--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -106,7 +106,7 @@ class Index extends BaseIndex
         return $this;
     }
 
-    public function searchUsingApi($query, array $options = ['hitsPerPage' => 1000000, 'showRankingScore' => true]): Collection
+    public function searchUsingApi($query, array $options = []): Collection
     {
         try {
             $searchResults = $this->getIndex()->search($query, $options);

--- a/src/Meilisearch/Query.php
+++ b/src/Meilisearch/Query.php
@@ -6,14 +6,27 @@ use Statamic\Search\QueryBuilder;
 
 class Query extends QueryBuilder
 {
+    /**
+     * The options to be sent with the search request.
+     * See https://www.meilisearch.com/docs/reference/api/search#body for available options.
+     */
+    public array $options = ['hitsPerPage' => 1000000, 'showRankingScore' => true];
+
     public function getSearchResults($query)
     {
-        $results = $this->index->searchUsingApi($query);
+        $results = $this->index->searchUsingApi($query, $this->options);
 
         return $results->map(function ($result, $i) {
             $result['search_score'] = (int) ceil($result['_rankingScore'] * 1000);
 
             return $result;
         });
+    }
+
+    public function orderBy($column, $direction = 'asc')
+    {
+        $this->options['sort'][] = "{$column}:{$direction}";
+
+        return parent::orderBy($column, $direction);
     }
 }


### PR DESCRIPTION
This pull request adds the option to sort the search results by using the `orderBy` function.

