### PR TITLE
Dispatch `SearchIndexUpdated` event

### DIFF
--- a/src/Meilisearch/Index.php
+++ b/src/Meilisearch/Index.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Meilisearch\Client;
 use Meilisearch\Exceptions\ApiException;
 use Statamic\Contracts\Search\Searchable;
+use Statamic\Events\SearchIndexUpdated;
 use Statamic\Search\Documents;
 use Statamic\Search\Index as BaseIndex;
 
@@ -102,6 +103,8 @@ class Index extends BaseIndex
         $this->createIndex();
 
         $this->searchables()->lazy()->each(fn ($searchables) => $this->insertMultiple($searchables));
+
+        SearchIndexUpdated::dispatch($this);
 
         return $this;
     }


### PR DESCRIPTION
In https://github.com/statamic/cms/pull/10459, a new `SearchIndexUpdated` event is being introduced. This pull request simply dispatches that event from the Meilisearch `Index::update()` method.

This PR should only be merged & tagged after statamic/cms#10459 has been tagged.