### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,8 +23,8 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.3, 8.4]
-                laravel: [12.*]
+                php: [8.3, 8.4, 8.5]
+                laravel: [12.*, 13.*]
                 stability: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
         "meilisearch/meilisearch-php": "^1.0",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/support": "^12.0",
-        "statamic/cms": "^6.0.0-beta.4",
-        "spatie/laravel-ray": "^1.0@dev"
+        "illuminate/support": "^12.0 || ^13.0",
+        "statamic/cms": "^6.0.0-beta.4"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^10.0",
-        "phpunit/phpunit": "^11.5.10"
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "phpunit/phpunit": "^11.5.10 || ^12.0",
+        "spatie/laravel-ray": "^1.43.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request adds Laravel 13 support to the Meilisearch addon. This PR also adds PHP 8.5 to the testing matrix.